### PR TITLE
Fix typo in admin config

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -151,7 +151,7 @@ collections:
       - label: "Short Name"
         name: "name"
         widget: "string"
-      - label: "Diplay Name"
+      - label: "Display Name"
         name: "display_name"
         widget: "string"
       - label: "Position"


### PR DESCRIPTION
## Summary
- fix label name in admin config

## Testing
- `grep -n "Display Name" admin/config.yml`
