### PR TITLE
Fix typo for 'HyperText Markup Language' in old posts

### DIFF
--- a/_old_posts/2010-01-01-welcome-to-the-desert-of-the-real.md
+++ b/_old_posts/2010-01-01-welcome-to-the-desert-of-the-real.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 * **To bold text**, use `<strong>`.
 * *To italicize text*, use `<em>`.
-* Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+* Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 * Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 * <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 * Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2010-03-03-why-books-should-be-your-priority.md
+++ b/_old_posts/2010-03-03-why-books-should-be-your-priority.md
@@ -28,7 +28,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2011-04-04-the-quick-brown-fox-jumps-over-a-lazy-dog.md
+++ b/_old_posts/2011-04-04-the-quick-brown-fox-jumps-over-a-lazy-dog.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2011-05-05-a-wonderful-serenity-has-taken-possession-of-my-entire-soul.md
+++ b/_old_posts/2011-05-05-a-wonderful-serenity-has-taken-possession-of-my-entire-soul.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2011-06-06-candy-candies-candy.md
+++ b/_old_posts/2011-06-06-candy-candies-candy.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2012-07-07-trust-me-it-will-work.md
+++ b/_old_posts/2012-07-07-trust-me-it-will-work.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2012-08-08-how-to-turn-your-dog-into-a-jedi-master.md
+++ b/_old_posts/2012-08-08-how-to-turn-your-dog-into-a-jedi-master.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2013-10-10-let-flexbox-work-for-you-or-perish.md
+++ b/_old_posts/2013-10-10-let-flexbox-work-for-you-or-perish.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2013-11-11-a-star-has-fallen-from-the-sky-and-the-cat-ate-it.md
+++ b/_old_posts/2013-11-11-a-star-has-fallen-from-the-sky-and-the-cat-ate-it.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2013-12-12-smoke-alert.md
+++ b/_old_posts/2013-12-12-smoke-alert.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2014-01-01-do-you-believe-that-a-spider-can-dance.md
+++ b/_old_posts/2014-01-01-do-you-believe-that-a-spider-can-dance.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2014-02-02-a-cook-cries-in-the-rain-at-night.md
+++ b/_old_posts/2014-02-02-a-cook-cries-in-the-rain-at-night.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2014-03-03-grab-your-band-and-get-out.md
+++ b/_old_posts/2014-03-03-grab-your-band-and-get-out.md
@@ -26,7 +26,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2015-09-06-passion-is-dangerous-go-for-it.md
+++ b/_old_posts/2015-09-06-passion-is-dangerous-go-for-it.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.

--- a/_old_posts/2019-09-09-birds-can-fly-but-this-you-knew-already.md
+++ b/_old_posts/2019-09-09-birds-can-fly-but-this-you-knew-already.md
@@ -25,7 +25,7 @@ HTML defines a long list of available inline tags, a complete list of which can 
 
 - **To bold text**, use `<strong>`.
 - *To italicize text*, use `<em>`.
-- Abbreviations, like <abbr title="HyperText Markup Langage">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
+- Abbreviations, like <abbr title="HyperText Markup Language">HTML</abbr> should use `<abbr>`, with an optional `title` attribute for the full phrase.
 - Citations, like <cite>&mdash; Thiago Rossener</cite>, should use `<cite>`.
 - <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 - Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.


### PR DESCRIPTION
## Summary
- fix 'HyperText Markup Language' spelling across `_old_posts`

## Testing
- `npm test` *(fails: missing script)*