### PR TITLE
Fix external menu links

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ menu:
   - title: Feed
     url: /feed.xml
 
+> **Note:** External links in the `menu` should include the full `http://` or `https://` prefix so they aren't prefixed with your site's URL.
+
 # Social Media Settings
 # Remove the item if you don't need it
 github_username: github_username

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -2,7 +2,7 @@
   {% for item in site.menu %}
     {% if item.title and item.url %}
       <li>
-        <a href="{{ site.url }}{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
+        <a href="{{ item.url | absolute_url }}">{{ item.title }}</a>
       </li>
     {% endif %}
   {% endfor %}

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -2,7 +2,7 @@
   {% for item in site.menu %}
     {% if item.title and item.url %}
       <li>
-        <a href="{{ item.url | absolute_url }}">{{ item.title }}</a>
+        <a href="{% if item.url contains 'http' %}{{ item.url }}{% else %}{{ item.url | relative_url }}{% endif %}">{{ item.title }}</a>
       </li>
     {% endif %}
   {% endfor %}

--- a/src/yml/site.yml
+++ b/src/yml/site.yml
@@ -34,7 +34,7 @@ menu:
   - title: Buy me a pizza
     url: https://www.buymeacoffee.com/koltregaskes
   - title: SHOP
-    url: bubble.com/people/koltregaskes/shop
+    url: https://bubble.com/people/koltregaskes/shop
   - title: Twitter
     url: https://twitter.com/koltregaskes
   - title: Instagram
@@ -44,7 +44,7 @@ menu:
   - title: Pinterest
     url: https://www.pinterest.co.uk/koltregaskes/
   - title: Photography
-    url: koltregaskesphotography.com/
+    url: https://koltregaskesphotography.com/
   - title: Links
     url: https://beacons.ai/koltregaskes
   - title: About


### PR DESCRIPTION
## Summary
- avoid prefixing URLs with site.baseurl
- set correct URL scheme for menu links
- document external link behavior

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684880a00df8833190854123bd4f7cf7